### PR TITLE
Setting bucket based on ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 node_modules
+.idea
+*.iml
+*.ipr
+*.iws

--- a/lib/context.js
+++ b/lib/context.js
@@ -7,7 +7,7 @@ module.exports = Context;
  * experiments are available to that user.
  */
 function Context(bucket, userId, stamp) {
-  this.bucket = bucket || utils.generateBucket();
+  this.bucket = bucket || utils.generateBucket(userId);
   this.userId = userId;
   this.stamp = stamp;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,13 +2,17 @@ var errors = require("./errors"),
     crypto = require("crypto"),
     idCounter = Math.round(Math.random() * 1000000);
 
-//exports.normalizeId = normalizeId;
+exports.normalizeId = normalizeId;
 exports.bucketInRange = bucketInRange;
 exports.generateBucket = generateBucket;
 exports.generateHash = generateHash;
 
-function generateBucket() {
-    return idCounter++ % 100; //placeholder counter until we come up with a better id generation algorithm
+function generateBucket(userId) {
+    if(userId && (typeof userId === 'number' || typeof userId === 'string')) {
+      return normalizeId(userId) % 100;
+    } else {
+      return idCounter++ % 100; //placeholder counter until we come up with a better id generation algorithm
+    }
 }
 
 function generateHash(content){
@@ -17,35 +21,35 @@ function generateHash(content){
   return hash.digest('hex');
 };
 
-//function hash(str) {
-//    var hash = 5381;
-//    var bytes = new Buffer(str, 'ascii');
-//
-//    for (var i = 0; i < bytes.length; i++) {
-//        hash = ((hash << 5) + hash) + bytes[i]; /* hash * 33 + c */
-//    }
-//    
-//    return hash;
-//}
-//
-///**
-// * Returns the normalized integer version of the given `userId`.
-// */
-//function normalizeId(userId) {
-//    var intId = NaN;
-//    
-//    if ('number' == typeof userId && !isNaN(userId)) {
-//      intId = parseInt(userId, 10);
-//    } else if ('string' == typeof userId) {
-//      intId = hash(userId);
-//    }
-//
-//    if (typeof intId != "number" || isNaN(intId)) {
-//        throw new errors.InvalidUserIdError(userId);
-//    }
-//
-//    return Math.abs(intId);
-//}
+function hash(str) {
+   var hash = 5381;
+   var bytes = new Buffer(str, 'ascii');
+
+   for (var i = 0; i < bytes.length; i++) {
+       hash = ((hash << 5) + hash) + bytes[i]; /* hash * 33 + c */
+   }
+
+   return hash;
+}
+
+/**
+* Returns the normalized integer version of the given `userId`.
+*/
+function normalizeId(userId) {
+   var intId = NaN;
+
+   if ('number' == typeof userId && !isNaN(userId)) {
+     intId = parseInt(userId, 10);
+   } else if ('string' == typeof userId) {
+     intId = hash(userId);
+   }
+
+   if (typeof intId != "number" || isNaN(intId)) {
+       throw new errors.InvalidUserIdError(userId);
+   }
+
+   return Math.abs(intId);
+}
 
 /**
  * Returns `true` if the given `bucket` is contained in the given range,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "FamilySearch Web Developers",
   "name": "experiment",
   "description": "A simple framework for running UI experiments in web apps",
-  "version": "0.5.0",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/fs-webdev/experiment.git"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "usererror": "1.0.1"
   },
   "devDependencies": {
-    "vows": "0.6.0",
+    "vows": "0.8.1",
     "mustache": "0.3.1-dev",
     "ejs": "0.5.0",
     "eco": "1.1.0-rc-1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "FamilySearch Web Developers",
   "name": "experiment",
   "description": "A simple framework for running UI experiments in web apps",
-  "version": "0.2.0",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/fs-webdev/experiment.git"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "FamilySearch Web Developers",
   "name": "experiment",
   "description": "A simple framework for running UI experiments in web apps",
-  "version": "0.4.0",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/fs-webdev/experiment.git"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "FamilySearch Web Developers",
   "name": "experiment",
   "description": "A simple framework for running UI experiments in web apps",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/fs-webdev/experiment.git"

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1,61 +1,61 @@
-//var assert = require("assert"),
-//    vows = require("vows"),
-//    errors = require("./../lib/errors"),
-//    utils = require("./../lib/utils");
-//
-//var itWorksProperlyAnd = function(userId, vows) {
-//  var base = {
-//      topic: utils.normalizeId(userId),
-//      "it returns a valid positive integer": function (normalized) {
-//        assert.isNumber(normalized);
-//        assert.equal(Math.floor(normalized), Math.ceil(normalized));
-//        assert.isTrue(normalized > 0);
-//      }
-//  }
-//  
-//  for (var key in vows) {
-//    base[key] = vows[key];
-//  }
-//  
-//  return base;
-//}
-//
-//vows.describe("utils").addBatch({
-//    "When I normalize a user id that is": {
-//        "undefined": {
-//            "it raises an error": function () {
-//                assert.throws( function() { utils.normalizeId() }, errors.InvalidUserIdError );
-//            },
-//        },
-//        "an object": {
-//            "it raises an error": function () {
-//                assert.throws( function() { utils.normalizeId( {} ) }, errors.InvalidUserIdError );
-//            },
-//        },
-//        "an integer,": itWorksProperlyAnd(1, {
-//            "it returns the given user id": function (normalized) {
-//                assert.equal(normalized, 1);
-//            }
-//        }),
-//        "a negative integer,": itWorksProperlyAnd(-1, {
-//            "it returns absolute value of the given user id": function (normalized) {
-//                assert.equal(normalized, 1);
-//            }
-//        }),
-//        "a float,": itWorksProperlyAnd(1.7, {
-//            "it truncates the given user id": function (normalized) {
-//                assert.equal(normalized, 1);
-//            }
-//        }),
-//        "a negative float,": itWorksProperlyAnd(-1.7, {
-//            "it truncates the absolute value of the given user id": function (normalized) {
-//                assert.equal(normalized, 1);
-//            }
-//        }),
-//        "a string": itWorksProperlyAnd("my string", {
-//            "returns a consistent integer": function (normalized) {
-//                assert.equal(normalized, 365786686);
-//            }
-//        })
-//    }
-//}).export(module);
+var assert = require("assert"),
+   vows = require("vows"),
+   errors = require("./../lib/errors"),
+   utils = require("./../lib/utils");
+
+var itWorksProperlyAnd = function(userId, vows) {
+ var base = {
+     topic: utils.normalizeId(userId),
+     "it returns a valid positive integer": function (normalized) {
+       assert.isNumber(normalized);
+       assert.equal(Math.floor(normalized), Math.ceil(normalized));
+       assert.isTrue(normalized > 0);
+     }
+ }
+
+ for (var key in vows) {
+   base[key] = vows[key];
+ }
+
+ return base;
+}
+
+vows.describe("utils").addBatch({
+   "When I normalize a user id that is": {
+       "undefined": {
+           "it raises an error": function () {
+               assert.throws( function() { utils.normalizeId() }, errors.InvalidUserIdError );
+           },
+       },
+       "an object": {
+           "it raises an error": function () {
+               assert.throws( function() { utils.normalizeId( {} ) }, errors.InvalidUserIdError );
+           },
+       },
+       "an integer,": itWorksProperlyAnd(1, {
+           "it returns the given user id": function (normalized) {
+               assert.equal(normalized, 1);
+           }
+       }),
+       "a negative integer,": itWorksProperlyAnd(-1, {
+           "it returns absolute value of the given user id": function (normalized) {
+               assert.equal(normalized, 1);
+           }
+       }),
+       "a float,": itWorksProperlyAnd(1.7, {
+           "it truncates the given user id": function (normalized) {
+               assert.equal(normalized, 1);
+           }
+       }),
+       "a negative float,": itWorksProperlyAnd(-1.7, {
+           "it truncates the absolute value of the given user id": function (normalized) {
+               assert.equal(normalized, 1);
+           }
+       }),
+       "a string": itWorksProperlyAnd("my string", {
+           "returns a consistent integer": function (normalized) {
+               assert.equal(normalized, 365786686);
+           }
+       })
+   }
+}).export(module);


### PR DESCRIPTION
There were old functions commented out that normalized the ID to an integer. I uncommented those and sent the userId to the generate bucket function. 

I also uncommented the tests for normalizeId, though I never could get _any_ of the tests to run even before adding these back in. 

This will fix the bucket to the userId, which is sent in through in woodruff and snow's experiments middleware. When userId is null or is the wrong type, the old way is used as the fallback.
